### PR TITLE
Added `EncoderInterface::encodeError`

### DIFF
--- a/src/Encoders/AbstractEncoder.php
+++ b/src/Encoders/AbstractEncoder.php
@@ -64,16 +64,11 @@ abstract class AbstractEncoder implements EncoderInterface
      * @param mixed $data
      * @param int|null $statusCode
      * @param string[]|null $headers
-     * @param string|null $errorKey
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function encodeError(
-        $data,
-        ?int $statusCode = null,
-        ?array $headers = null,
-        ?string $errorKey = null
-    ): ResponseInterface {
+    public function encodeError($data, ?int $statusCode = null, ?array $headers = null): ResponseInterface
+    {
         return $this->encode($data, $statusCode, $headers);
     }
 

--- a/src/Encoders/AbstractEncoder.php
+++ b/src/Encoders/AbstractEncoder.php
@@ -59,6 +59,25 @@ abstract class AbstractEncoder implements EncoderInterface
     }
 
     /**
+     * Create error response from given data, status code and headers.
+     *
+     * @param mixed $data
+     * @param int|null $statusCode
+     * @param string[]|null $headers
+     * @param string|null $errorKey
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function encodeError(
+        $data,
+        ?int $statusCode = null,
+        ?array $headers = null,
+        ?string $errorKey = null
+    ): ResponseInterface {
+        return $this->encode($data, $statusCode, $headers);
+    }
+
+    /**
      * Manually set content to decode.
      *
      * @param string $content

--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -88,11 +88,7 @@ class JsonApiEncoder extends AbstractEncoder
             $errors = [$errors];
         }
 
-        return $this->response(
-            \json_encode(['errors' => $errors]) ?: '',
-            $statusCode,
-            $headers
-        );
+        return $this->response(\json_encode(['errors' => $errors]) ?: '', $statusCode, $headers);
     }
 
     /**

--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -72,6 +72,29 @@ class JsonApiEncoder extends AbstractEncoder
     }
 
     /**
+     * Create error response from given data, status code and headers.
+     *
+     * @param mixed $data
+     * @param int|null $statusCode
+     * @param string[]|null $headers
+     * @param string|null $errorKey
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function encodeError(
+        $data,
+        ?int $statusCode = null,
+        ?array $headers = null,
+        ?string $errorKey = null
+    ): ResponseInterface {
+        return $this->response(
+            \json_encode([$errorKey ?? 'errors' => $this->getDataAsArray($data)]) ?: '',
+            $statusCode,
+            $headers
+        );
+    }
+
+    /**
      * Decode request content to array.
      *
      * @param string $content

--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -77,18 +77,19 @@ class JsonApiEncoder extends AbstractEncoder
      * @param mixed $data
      * @param int|null $statusCode
      * @param string[]|null $headers
-     * @param string|null $errorKey
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function encodeError(
-        $data,
-        ?int $statusCode = null,
-        ?array $headers = null,
-        ?string $errorKey = null
-    ): ResponseInterface {
+    public function encodeError($data, ?int $statusCode = null, ?array $headers = null): ResponseInterface
+    {
+        $errors = $this->getDataAsArray($data);
+
+        if ($this->isCollection($data) === false) {
+            $errors = [$errors];
+        }
+
         return $this->response(
-            \json_encode([$errorKey ?? 'errors' => $this->getDataAsArray($data)]) ?: '',
+            \json_encode(['errors' => $errors]) ?: '',
             $statusCode,
             $headers
         );

--- a/src/Interfaces/EncoderInterface.php
+++ b/src/Interfaces/EncoderInterface.php
@@ -31,16 +31,10 @@ interface EncoderInterface
      * @param mixed $data
      * @param int|null $statusCode
      * @param string[]|null $headers
-     * @param string|null $errorKey
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    public function encodeError(
-        $data,
-        ?int $statusCode = null,
-        ?array $headers = null,
-        ?string $errorKey = null
-    ): ResponseInterface;
+    public function encodeError($data, ?int $statusCode = null, ?array $headers = null): ResponseInterface;
 
     /**
      * Manually set content to decode.

--- a/src/Interfaces/EncoderInterface.php
+++ b/src/Interfaces/EncoderInterface.php
@@ -26,6 +26,23 @@ interface EncoderInterface
     public function encode($data, ?int $statusCode = null, ?array $headers = null): ResponseInterface;
 
     /**
+     * Create error response from given data, status code and headers.
+     *
+     * @param mixed $data
+     * @param int|null $statusCode
+     * @param string[]|null $headers
+     * @param string|null $errorKey
+     *
+     * @return \Psr\Http\Message\ResponseInterface
+     */
+    public function encodeError(
+        $data,
+        ?int $statusCode = null,
+        ?array $headers = null,
+        ?string $errorKey = null
+    ): ResponseInterface;
+
+    /**
      * Manually set content to decode.
      *
      * @param string $content

--- a/tests/Encoders/RequestEncodersTest.php
+++ b/tests/Encoders/RequestEncodersTest.php
@@ -42,6 +42,23 @@ class RequestEncodersTest extends RequestEncoderGuesserTestCase
     }
 
     /**
+     * Encoders::encodeError should return ResponseInterface.
+     *
+     * @return void
+     */
+    public function testEncodeErrorReturnsResponseInterface(): void
+    {
+        foreach (static::$encoders as $encoderClass) {
+            /** @var \EoneoPay\ApiFormats\Interfaces\EncoderInterface $encoder */
+            $encoder = new $encoderClass($this->getRequest());
+
+            foreach ($this->getEncodersTests() as $test) {
+                self::assertTrue(\is_subclass_of($encoder->encodeError($test), ResponseInterface::class));
+            }
+        }
+    }
+
+    /**
      * Encoders::encode should return ResponseInterface no matters the input.
      *
      * @return void

--- a/tests/Encoders/RequestEncodersTest.php
+++ b/tests/Encoders/RequestEncodersTest.php
@@ -53,6 +53,12 @@ class RequestEncodersTest extends RequestEncoderGuesserTestCase
             $encoder = new $encoderClass($this->getRequest());
 
             foreach ($this->getEncodersTests() as $test) {
+                if ($encoder instanceof JsonApiEncoder) {
+                    // Always encode errors as an array
+                    self::assertTrue(\is_subclass_of($encoder->encodeError([$test]), ResponseInterface::class));
+
+                    continue;
+                }
                 self::assertTrue(\is_subclass_of($encoder->encodeError($test), ResponseInterface::class));
             }
         }


### PR DESCRIPTION
Added `EncoderInterface::encodeError` to be used in returning error responses that may have different format from non error responses.
Implemented `JsonApiEncoder::encodeError` to wrap data inside an `errors` key for response.
Implemented default `AbstractEncoder::encodeError` to just call `encode`.