### PR TITLE
Update JsonApiEncoder to handler collections and instantiated transformers

### DIFF
--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -12,6 +12,7 @@ use League\Fractal\Resource\Collection;
 use League\Fractal\Resource\Item;
 use League\Fractal\Resource\NullResource;
 use League\Fractal\Serializer\JsonApiSerializer;
+use League\Fractal\TransformerAbstract;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -152,9 +153,13 @@ class JsonApiEncoder extends AbstractEncoder
     {
         // If data is an object and defines getTransformer method we use it
         if ($data instanceof SerializableInterface && \method_exists($data, 'getTransformer')) {
-            $transformerClass = $data->getTransformer();
+            $transformer = $data->getTransformer();
 
-            return new $transformerClass();
+            if ($transformer instanceof TransformerAbstract) {
+                return $transformer;
+            }
+
+            return new $transformer();
         }
 
         // Fallback to generic closure

--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -5,6 +5,7 @@ namespace EoneoPay\ApiFormats\Encoders;
 
 use EoneoPay\ApiFormats\External\Interfaces\JsonApi\JsonApiConverterInterface;
 use EoneoPay\ApiFormats\External\Libraries\JsonApi\JsonApiConverter;
+use EoneoPay\Utils\Interfaces\CollectionInterface;
 use EoneoPay\Utils\Interfaces\SerializableInterface;
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
@@ -122,6 +123,11 @@ class JsonApiEncoder extends AbstractEncoder
      */
     private function getResourceClass($data): string
     {
+        // Check if collection first since CollectionInterface extends SerializableInterface
+        if ($data instanceof CollectionInterface) {
+            return Collection::class;
+        }
+
         // If single item as object
         if ($data instanceof SerializableInterface) {
             return Item::class;

--- a/tests/Stubs/CollectionInterfaceStub.php
+++ b/tests/Stubs/CollectionInterfaceStub.php
@@ -1,0 +1,256 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\ApiFormats\Stubs;
+
+use EoneoPay\Utils\Interfaces\CollectionInterface;
+use EoneoPay\Utils\Interfaces\SerializableInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.ExcessiveClassComplexity) Collection is massive and requires all functionality
+ * @SuppressWarnings(PHPMD.TooManyPublicMethods) Collection requires many public methods to work
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter) For testing purposes, some methods are empty
+ */
+final class CollectionInterfaceStub implements CollectionInterface
+{
+    /**
+     * Convert collection to string
+     *
+     * @return string
+     */
+    public function __toString(): string
+    {
+        return $this->toJson();
+    }
+
+    /**
+     * Add an item to the collection
+     *
+     * @param mixed $item The item to add to the collection
+     *
+     * @return static
+     */
+    public function add($item)
+    {
+        return $this;
+    }
+
+    /**
+     * Clear all items from a collection
+     *
+     * @return static
+     */
+    public function clear()
+    {
+        return $this;
+    }
+
+    /**
+     * Collapse the collection of items into a single array
+     *
+     * @return static
+     */
+    public function collapse()
+    {
+        return $this;
+    }
+
+    /**
+     * Run a filter over each of the items
+     *
+     * @param callable $callback A callback to process against the items
+     *
+     * @return static
+     */
+    public function filter(callable $callback)
+    {
+        return $this;
+    }
+
+    /**
+     * Get the first item in the collection
+     *
+     * @return mixed The first item
+     */
+    public function first()
+    {
+        return 'first-item';
+    }
+
+    /**
+     * Get item by key
+     *
+     * @param mixed $key The item to get
+     * @param mixed $default The value to return if key isn't found
+     *
+     * @return mixed
+     */
+    public function get($key, $default = null)
+    {
+        return 'get-item';
+    }
+
+    /**
+     * Get the items from the collection
+     *
+     * @return mixed[]
+     */
+    public function getItems(): array
+    {
+        return [];
+    }
+
+    /**
+     * Determine if the collection has a specific key
+     *
+     * @param string $key The key to search for, can use dot notation
+     *
+     * @return bool
+     */
+    public function has(string $key): bool
+    {
+        return true;
+    }
+
+    /**
+     * Copy keys from one collection to this collection if keys exist in both
+     *
+     * @param \EoneoPay\Utils\Interfaces\SerializableInterface $source The source to check for the key in
+     * @param mixed[] $keys The destination/source key pairs to process
+     *
+     * @return void
+     */
+    public function intersect(SerializableInterface $source, array $keys): void
+    {
+    }
+
+    /**
+     * Specify data which should be serialized to JSON
+     *
+     * @link https://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     * which is a value of any type other than a resource.
+     *
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Get the last item in the collection
+     *
+     * @return mixed
+     */
+    public function last()
+    {
+        return 'last-item';
+    }
+
+    /**
+     * Run a map over each of the items
+     *
+     * @param callable $callback A callback to process against the items
+     *
+     * @return static
+     */
+    public function map(callable $callback)
+    {
+        return $this;
+    }
+
+    /**
+     * Recursively merge an array into the collection
+     *
+     * @param mixed[] $data The data to merge into the collection
+     *
+     * @return void
+     */
+    public function merge(array $data): void
+    {
+    }
+
+    /**
+     * Get nth item from the items
+     *
+     * @param int $nth The item to get
+     *
+     * @return mixed
+     */
+    public function nth(int $nth)
+    {
+        return 'nth-item';
+    }
+
+    /**
+     * Remove an item from a collection
+     *
+     * @param mixed $item The item to remove
+     *
+     * @return static
+     */
+    public function remove($item)
+    {
+        return $this;
+    }
+
+    /**
+     * Recursively replace an array's values into the collection
+     *
+     * @param mixed[] $data The data to replace in the collection
+     *
+     * @return void
+     */
+    public function replace(array $data): void
+    {
+    }
+
+    /**
+     * Set a value to the collection
+     *
+     * @param string $key The key to set to the collection, can use dot notation
+     * @param mixed $value The value to set for this key
+     *
+     * @return void
+     */
+    public function set(string $key, $value): void
+    {
+    }
+
+    /**
+     * Get the contents of the repository as an array
+     *
+     * @return mixed[]
+     */
+    public function toArray(): array
+    {
+        return [
+            ['id' => 'id-1'],
+            ['id' => 'id-2']
+        ];
+    }
+
+    /**
+     * Generate json from the repository
+     *
+     * @return string
+     */
+    public function toJson(): string
+    {
+        return \json_encode($this->jsonSerialize()) ?: '';
+    }
+
+    /**
+     * Generate XML string from the repository
+     *
+     * @param string|null $rootNode The name of the root node
+     *
+     * @return string|null
+     */
+    public function toXml(?string $rootNode = null): ?string
+    {
+        return '<xml></xml>';
+    }
+}

--- a/tests/Stubs/TransformerAbstractAwareSerializableStub.php
+++ b/tests/Stubs/TransformerAbstractAwareSerializableStub.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\ApiFormats\Stubs;
+
+use Tests\EoneoPay\ApiFormats\Stubs\Transformers\SerializableInterfaceTransformer;
+
+class TransformerAbstractAwareSerializableStub extends SerializableInterfaceStub
+{
+    /**
+     * Return instance of TransformerAbstract.
+     *
+     * @return \Tests\EoneoPay\ApiFormats\Stubs\Transformers\SerializableInterfaceTransformer
+     */
+    public function getTransformer(): SerializableInterfaceTransformer
+    {
+        return new SerializableInterfaceTransformer();
+    }
+}

--- a/tests/TestCases/RequestEncoderGuesserTestCase.php
+++ b/tests/TestCases/RequestEncoderGuesserTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Tests\EoneoPay\ApiFormats\TestCases;
 
 use PHPUnit\Framework\TestCase;
+use Tests\EoneoPay\ApiFormats\Stubs\CollectionInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStubWithToResponseArray;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceWithGettersStub;
@@ -19,6 +20,7 @@ abstract class RequestEncoderGuesserTestCase extends TestCase
     protected function getEncodersTests(): array
     {
         return [
+            new CollectionInterfaceStub(),
             new SerializableInterfaceStub(), // Single item
             new SerializableInterfaceWithGettersStub(), // Single item with getters
             (new SerializableInterfaceStub())->toArray(), // Single item as array

--- a/tests/TestCases/RequestEncoderGuesserTestCase.php
+++ b/tests/TestCases/RequestEncoderGuesserTestCase.php
@@ -8,6 +8,7 @@ use Tests\EoneoPay\ApiFormats\Stubs\CollectionInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStubWithToResponseArray;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceWithGettersStub;
+use Tests\EoneoPay\ApiFormats\Stubs\TransformerAbstractAwareSerializableStub;
 use Zend\Diactoros\ServerRequest;
 
 abstract class RequestEncoderGuesserTestCase extends TestCase
@@ -27,7 +28,8 @@ abstract class RequestEncoderGuesserTestCase extends TestCase
             [], // Empty response
             [new SerializableInterfaceWithGettersStub(), (new SerializableInterfaceStub())->toArray()], // Collection,
             new SerializableInterfaceStubWithToResponseArray(), // toResponseArray method
-            new \stdClass()
+            new \stdClass(),
+            new TransformerAbstractAwareSerializableStub()
         ];
     }
 


### PR DESCRIPTION
Updated `JsonApiEncoder::getResourceClass` to return `League\Fractal\Resource\Collection` if passed data is a `EoneoPay\Utils\Interfaces\CollectionInterface` for Transformers to handle collections properly.