### PR TITLE
Fix `is_callable` uses and change to `method_exists`

### DIFF
--- a/src/Encoders/AbstractEncoder.php
+++ b/src/Encoders/AbstractEncoder.php
@@ -115,8 +115,8 @@ abstract class AbstractEncoder implements EncoderInterface
     {
         $toResponseArray = [$data, 'toResponseArray'];
         // If this is serialisable or implements to response array, call it
-        if (($data instanceof SerializableInterface) === true || \is_callable($toResponseArray) === true) {
-            return \is_callable($toResponseArray) === true ? $toResponseArray() : $data->toArray();
+        if (($data instanceof SerializableInterface) === true || \method_exists(...$toResponseArray) === true) {
+            return \method_exists(...$toResponseArray) === true ? $toResponseArray() : $data->toArray();
         }
 
         // If given data is not iterable, cast result

--- a/src/Encoders/JsonApiEncoder.php
+++ b/src/Encoders/JsonApiEncoder.php
@@ -164,7 +164,7 @@ class JsonApiEncoder extends AbstractEncoder
     {
         // If data is an object and defines getTransformer method we use it
         $getTransformer = [$data, 'getTransformer'];
-        if (($data instanceof SerializableInterface) === true && \is_callable($getTransformer) === true) {
+        if (($data instanceof SerializableInterface) === true && \method_exists(...$getTransformer) === true) {
             $transformer = $getTransformer();
 
             if (($transformer instanceof TransformerAbstract) === true) {

--- a/tests/Stubs/SerializableWithMagicCallStub.php
+++ b/tests/Stubs/SerializableWithMagicCallStub.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace Tests\EoneoPay\ApiFormats\Stubs;
+
+final class SerializableWithMagicCallStub extends SerializableInterfaceStub
+{
+    /**
+     * Stub implementation that should not be called.
+     *
+     * @param string $name
+     * @param mixed[] $arguments
+     *
+     * @return void
+     */
+    public function __call(string $name, array $arguments): void
+    {
+        throw new \BadMethodCallException(\sprintf(
+            'Call to undefined method %s::%s()',
+            \get_class($this),
+            $name
+        ));
+    }
+}

--- a/tests/TestCases/RequestEncoderGuesserTestCase.php
+++ b/tests/TestCases/RequestEncoderGuesserTestCase.php
@@ -8,6 +8,7 @@ use Tests\EoneoPay\ApiFormats\Stubs\CollectionInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStub;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceStubWithToResponseArray;
 use Tests\EoneoPay\ApiFormats\Stubs\SerializableInterfaceWithGettersStub;
+use Tests\EoneoPay\ApiFormats\Stubs\SerializableWithMagicCallStub;
 use Tests\EoneoPay\ApiFormats\Stubs\TransformerAbstractAwareSerializableStub;
 use Zend\Diactoros\ServerRequest;
 
@@ -29,7 +30,8 @@ abstract class RequestEncoderGuesserTestCase extends TestCase
             [new SerializableInterfaceWithGettersStub(), (new SerializableInterfaceStub())->toArray()], // Collection,
             new SerializableInterfaceStubWithToResponseArray(), // toResponseArray method
             new \stdClass(),
-            new TransformerAbstractAwareSerializableStub()
+            new TransformerAbstractAwareSerializableStub(),
+            new SerializableWithMagicCallStub()
         ];
     }
 


### PR DESCRIPTION
Fix `is_callable` uses and change to `method_exists` since `is_callable` returns true if object being tested implements `__call` magic method.
- updated `toResponseArray` method check
- updated `getTransformer` method check